### PR TITLE
LevelData import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 *.pyc
+
+.vscode

--- a/__init__.py
+++ b/__init__.py
@@ -77,6 +77,7 @@ class SelectNoesisExecutable(bpy.types.Operator, ImportHelper):
 class Replicant2BlenderPreferences(bpy.types.AddonPreferences):
     bl_idname = __package__
     #noesis_path : StringProperty(default="D:\\Programs\\Noesis\\Noesis.exe", options={'HIDDEN'})
+    noesis_path : StringProperty(options={'HIDDEN'})
     assets_path : StringProperty(options={'HIDDEN'})
 
     def draw(self, context):

--- a/__init__.py
+++ b/__init__.py
@@ -77,7 +77,7 @@ class SelectNoesisExecutable(bpy.types.Operator, ImportHelper):
 class Replicant2BlenderPreferences(bpy.types.AddonPreferences):
     bl_idname = __package__
     #noesis_path : StringProperty(default="D:\\Programs\\Noesis\\Noesis.exe", options={'HIDDEN'})
-    noesis_path : StringProperty(default="", options={'HIDDEN'})
+    assets_path : StringProperty(options={'HIDDEN'})
 
     def draw(self, context):
         layout = self.layout
@@ -90,6 +90,9 @@ class Replicant2BlenderPreferences(bpy.types.AddonPreferences):
         row = layout.row()
         row.prop(self, "noesis_path", text="")
         row.operator("replicant.noesis_select", icon="FILE_TICK", text="")
+        layout.label(text="Path To Assets Folder:")
+        row = layout.row()
+        row.prop(self, "assets_path", text="")
             
 
 # Registration

--- a/__init__.py
+++ b/__init__.py
@@ -32,16 +32,34 @@ class ImportReplicantMeshPack(bpy.types.Operator, ImportHelper):
     extract_textures: bpy.props.BoolProperty(name="Extract Textures (Slow)", description="This automatically extracts and converts textures to PNG (Requires the user to have setup Noesis in this add-on's preferences)", default=True)
     construct_materials: bpy.props.BoolProperty(name="Construct Materials", description="This automatically sets up materials with the appropriate textures (Requires the user to have extracted the textures at least once before)", default=True)
     only_extract_textures: bpy.props.BoolProperty(name="Only Extract Textures", description="This can be used to simply extract the textures from a PACK containing some, nothing else will be done (Requires the user to have setup Noesis in this add-on's preferences)", default=False)
+    all_meshes_in_folder: bpy.props.BoolProperty(name="All Meshes In Folder", description="This can be used to import all PACK files in the same folder as the selected file", default=False)
+    all_meshes_in_folder_recursive: bpy.props.BoolProperty(name="All Meshes In Folder (Recursive)", description="This can be used to import all PACK files in the same folder as the selected file, and all PACK files in subfolders", default=False)
 
     def execute(self, context):
-        directory = self.directory
-        for file_elem in self.files:
-            filepath = os.path.join(directory, file_elem.name)
+        def importFile(filepath):
             if os.path.isfile(filepath):
                 if self.only_extract_textures:
                     pack_import.only_extract_textures(filepath, self.batch_size, __name__)
                 else:
                     pack_import.main(filepath, self.extract_textures, self.construct_materials, self.batch_size, __name__)
+        directory = self.directory
+        if self.all_meshes_in_folder:
+            for file in os.listdir(directory):
+                if not file.startswith("msh_"):
+                    continue
+                filepath = os.path.join(directory, file)
+                importFile(filepath)
+        elif self.all_meshes_in_folder_recursive:
+            for root, dirs, files in os.walk(directory):
+                for file in files:
+                    if not file.startswith("msh_"):
+                        continue
+                    filepath = os.path.join(root, file)
+                    importFile(filepath)
+        else:
+            for file_elem in self.files:
+                filepath = os.path.join(directory, file_elem.name)
+                importFile(filepath)
         pack_import.clear_importLists()
         return {"FINISHED"}
 

--- a/classes/bxon.py
+++ b/classes/bxon.py
@@ -1,3 +1,4 @@
+from .levelData import LevelData
 from ..util import *
 from .tpGxAssetHeader import tpGxAssetHeader
 from .tpGxMeshHead import tpGxMeshHead
@@ -26,6 +27,8 @@ class BXON:
             self.meshHead = tpGxMeshHead(packFile)
         elif (self.fileTypeName == "tpGxTexHead"):
             self.texHead = tpGxTexHead(packFile)
+        elif (self.fileTypeName == "LevelData"):
+            self.levelData = LevelData(packFile)
 
         packFile.seek(returnPos)
 

--- a/classes/levelData.py
+++ b/classes/levelData.py
@@ -94,6 +94,7 @@ class LDEntry:
     objects: list[LDObject]
 
     def __init__(self, packFile: BinaryIO):
+        returnPos = packFile.tell() + 12
         skip(packFile, 4)
 
         # entryCount = to_uint(packFile.read(4))
@@ -108,6 +109,8 @@ class LDEntry:
         self.objects = []
         for i in range(entryCount):
             self.objects.append(LDObject(packFile))
+
+        packFile.seek(returnPos)
 
 
 class LevelData:

--- a/classes/levelData.py
+++ b/classes/levelData.py
@@ -1,0 +1,128 @@
+from typing import BinaryIO
+import os
+
+from ..util import readFloatX4, readString, to_float, to_string, to_uint, readFloatX3
+
+def skip(file: BinaryIO, count: int):
+    file.seek(count, os.SEEK_CUR)
+
+def skipPadding(file: BinaryIO, alignment: int):
+    padding = alignment - (file.tell() % alignment)
+    if (padding != alignment):
+        file.seek(padding, os.SEEK_CUR)
+
+def seekToRelOffset(file: BinaryIO, ownOffset: int = -4):
+    offset = to_uint(file.read(4))
+    file.seek(offset + ownOffset, 1)
+
+def readStringFromOffset(file: BinaryIO, ownOffset: int = -4):
+    offset = to_uint(file.read(4))
+    returnPos = file.tell()
+    file.seek(offset + ownOffset, 1)
+    string = readString(file)
+    file.seek(returnPos)
+    return string
+
+class LDMeshEntry:
+    def __init__(self, packFile: BinaryIO):
+        self.pos = readFloatX3(packFile)
+        self.rot = readFloatX4(packFile)
+        self.scale = to_float(packFile.read(4))
+        self.unkn0 = to_uint(packFile.read(4))
+        self.unkn1 = to_uint(packFile.read(4))
+        self.unkn2 = to_float(packFile.read(4))
+        self.unkn3 = readFloatX3(packFile)
+        self.unkn4 = readFloatX3(packFile)
+        self.unkn5 = to_float(packFile.read(4))
+        self.unkn6 = to_float(packFile.read(4))
+        self.unkn7 = to_float(packFile.read(4))
+        self.unkn8 = to_float(packFile.read(4))
+        self.unkn9 = to_float(packFile.read(4))
+        self.null0 = to_uint(packFile.read(2))
+        self.unkn10 = to_uint(packFile.read(1))
+        self.unkn11 = to_uint(packFile.read(1))
+        self.unkn12 = to_uint(packFile.read(4))
+        self.null1 = to_uint(packFile.read(1))
+        skipPadding(packFile, 4)
+        skip(packFile, 8)
+        skipPadding(packFile, 8)
+        self.meshPath = readString(packFile)
+
+class LDUnknEntry10:
+    def __init__(self, packFile: BinaryIO):
+        self.pos = readFloatX3(packFile)
+        self.rot = readFloatX4(packFile)
+        self.scale = to_float(packFile.read(4))
+        ...
+
+class LDUnknEntry18:
+    def __init__(self, packFile: BinaryIO):
+        self.pos = readFloatX3(packFile)
+        self.rot = readFloatX4(packFile)
+        self.scale = to_float(packFile.read(4))
+        self.unkn0 = to_uint(packFile.read(4))
+        self.unknPath = readStringFromOffset(packFile)
+        ...
+
+class LDObject:
+    meshEntry: LDMeshEntry|None
+    unknEntry18: LDUnknEntry18|None
+    unknEntry10: LDUnknEntry10|None
+
+    def __init__(self, packFile: BinaryIO):
+        returnPos = packFile.tell() + 4
+        seekToRelOffset(packFile)
+
+        objType = to_uint(packFile.read(4))
+        unkn0 = to_uint(packFile.read(4))
+
+        self.meshEntry = None
+        self.unknEntry10 = None
+        self.unknEntry18 = None
+        if (objType == 8):
+            self.meshEntry = LDMeshEntry(packFile)
+        elif (objType == 10):
+            self.unknEntry10 = LDUnknEntry10(packFile)
+        elif (objType == 18):
+            self.unknEntry18 = LDUnknEntry18(packFile)
+        # else:
+        #     raise Exception(f"Unknown object type {objType} at {returnPos}")
+
+        packFile.seek(returnPos)
+
+class LDEntry:
+    objects: list[LDObject]
+
+    def __init__(self, packFile: BinaryIO):
+        skip(packFile, 4)
+
+        # entryCount = to_uint(packFile.read(4))
+        skip(packFile, 4)
+
+        seekToRelOffset(packFile)
+        skip(packFile, 4)
+
+        entryCount = to_uint(packFile.read(4))
+
+        seekToRelOffset(packFile)
+        self.objects = []
+        for i in range(entryCount):
+            self.objects.append(LDObject(packFile))
+
+
+class LevelData:
+    entries: list[LDEntry]
+
+    def __init__(self, packFile: BinaryIO):
+        # header = packFile.read(18)
+        # if to_string(header) != "LevelData":
+        #     raise Exception("LevelData header not found")
+        # skipPadding(packFile, 8)
+
+        entryCount = to_uint(packFile.read(4))
+
+        seekToRelOffset(packFile)
+        self.entries = []
+        for i in range(entryCount):
+            self.entries.append(LDEntry(packFile))
+

--- a/classes/pack.py
+++ b/classes/pack.py
@@ -36,27 +36,30 @@ class Pack:
         
         print(" - Pack AssetPacks:")
         packFile.seek(offsetAssetPacks)
-        self.assetPacks = []
+        self.assetPacks: list[AssetPack] = []
         for i in range(self.assetPackCount):
             self.assetPacks.append(AssetPack(packFile))
 
         print(" - Pack Files:")
         packFile.seek(offsetFiles)
-        self.assetFiles = []
+        self.assetFiles: list[File] = []
         for i in range(self.fileCount):
             self.assetFiles.append(File(packFile))
 
         packFile.seek(self.packFileSerializedSize)
         self.meshData = []
         self.texData = []
+        self.levelData: list[LevelData] = []
         for assetFile in self.assetFiles:
-            if (assetFile.content == None or assetFile.content.fileTypeName not in ["tpGxMeshHead", "tpGxTexHead"]):
+            if (assetFile.content == None or assetFile.content.fileTypeName not in ["tpGxMeshHead", "tpGxTexHead", "LevelData"]):
                 continue
 
             if (assetFile.content.fileTypeName == "tpGxMeshHead"):
                 self.meshData.append(tpGxMeshData(packFile, assetFile.content.meshHead))
             elif (assetFile.content.fileTypeName == "tpGxTexHead"):
                 self.texData.append(tpGxTexData(packFile, assetFile.content.texHead))
+            elif (assetFile.content.fileTypeName == "LevelData"):
+                self.levelData.append(assetFile.content.levelData)
 
             if ((packFile.tell() - self.packFileSerializedSize) % 32 != 0):
                 alignRelative(packFile, self.packFileSerializedSize, 32)

--- a/importers/levelData_import.py
+++ b/importers/levelData_import.py
@@ -1,9 +1,10 @@
+import os
 import bpy
 
 from ..classes.levelData import LDMeshEntry, LDUnknEntry10, LDUnknEntry18, LevelData
 
 
-def importLevelData(levelDataList: list[LevelData]):
+def importLevelData(levelDataList: list[LevelData], addonName: str):
     if len(levelDataList) > 0:
         print("Importing LevelData...")
     else:
@@ -19,39 +20,43 @@ def importLevelData(levelDataList: list[LevelData]):
         for ldEntry in levelData.entries:
             for ldObject in ldEntry.objects:
                 if ldObject.meshEntry is not None:
-                    importLdMeshEntry(ldObject.meshEntry, rootCollection)
+                    importLdMeshEntry(ldObject.meshEntry, rootCollection, addonName)
                 elif ldObject.unknEntry10 is not None:
-                    importLdUnknEntry10(ldObject.unknEntry10, rootCollection)
+                    importLdUnknEntry10(ldObject.unknEntry10, rootCollection, addonName)
                 elif ldObject.unknEntry18 is not None:
-                    importLdUnknEntry18(ldObject.unknEntry18, rootCollection)
+                    importLdUnknEntry18(ldObject.unknEntry18, rootCollection, addonName)
 
     print("Done importing LevelData!")
 
-def importLdMeshEntry(meshEntry: LDMeshEntry, collection: bpy.types.Collection):
+def importLdMeshEntry(meshEntry: LDMeshEntry, collection: bpy.types.Collection, addonName: str):
     makeObj(
         meshEntry.pos,
         meshEntry.rot,
         meshEntry.scale,
         meshEntry.meshPath.split("/")[-1],
         collection,
+        addonName,
+        assetPath=meshEntry.meshPath
     )
 
-def importLdUnknEntry10(unknEntry10: LDUnknEntry10, collection: bpy.types.Collection):
+def importLdUnknEntry10(unknEntry10: LDUnknEntry10, collection: bpy.types.Collection, addonName: str):
     makeObj(
         unknEntry10.pos,
         unknEntry10.rot,
         unknEntry10.scale,
         "UnknEntry10",
         collection,
+        addonName
     )
 
-def importLdUnknEntry18(unknEntry18: LDUnknEntry18, collection: bpy.types.Collection):
+def importLdUnknEntry18(unknEntry18: LDUnknEntry18, collection: bpy.types.Collection, addonName: str):
     makeObj(
         unknEntry18.pos,
         unknEntry18.rot,
         unknEntry18.scale,
         unknEntry18.unknPath.split("/")[-1],
         collection,
+        addonName
     )
 
 def transformCoords(coords: tuple[float, float, float], invertY = -1):
@@ -63,10 +68,43 @@ def makeObj(
     scale: float,
     name: str,
     collection: bpy.types.Collection,
+    addonName: str,
+    assetPath: str|None = None,
 ):
     obj = bpy.data.objects.new(name, None)
+    collection.objects.link(obj)
     obj.location = transformCoords(pos)
     obj.rotation_euler = transformCoords(rot[:3])
     obj.scale = (scale, scale, scale)
-    collection.objects.link(obj)
+    if assetPath is not None:
+        assetColl = linkAssetModel(assetPath, addonName)
+        if assetColl is not None:
+            obj.instance_collection = assetColl
+            obj.instance_type = "COLLECTION"
     return obj
+
+def linkAssetModel(assetPath: str, addonName: str) -> bpy.types.Collection | None:
+    prefs = bpy.context.preferences.addons[addonName].preferences
+    assetsRootDir = prefs.assets_path
+
+    assetName = os.path.basename(assetPath)
+    assetCollName = os.path.basename(assetPath) + "_asset"
+
+    # link file for first object
+    if assetCollName not in bpy.data.collections:
+        assetPathParts = assetPath.split("/") if "/" in assetPath else assetPath.split("\\")
+        assetPathParts[-1] = assetName + ".blend"
+        filePath = os.path.join(assetsRootDir, *assetPathParts)
+        if not os.path.isfile(filePath):
+            return None
+
+        if assetName in bpy.data.libraries:
+            bpy.data.libraries.remove(bpy.data.libraries[assetName])
+        with bpy.data.libraries.load(filepath = filePath, link = True, relative = True) as (data_from, data_to):
+            data_to.collections = [assetName]
+        if assetName in bpy.data.objects and bpy.data.objects[assetName].instance_type == "COLLECTION":
+            bpy.data.objects.remove(bpy.data.objects[assetName], do_unlink=True)
+        linkedColl = bpy.data.collections[assetName]
+        linkedColl.name = assetCollName
+
+    return bpy.data.collections[assetCollName]

--- a/importers/levelData_import.py
+++ b/importers/levelData_import.py
@@ -88,7 +88,7 @@ def linkAssetModel(assetPath: str, addonName: str) -> bpy.types.Collection | Non
     assetsRootDir = prefs.assets_path
 
     assetName = os.path.basename(assetPath)
-    assetCollName = os.path.basename(assetPath) + "_asset"
+    assetCollName = assetName
 
     # link file for first object
     if assetCollName not in bpy.data.collections:

--- a/importers/levelData_import.py
+++ b/importers/levelData_import.py
@@ -1,0 +1,72 @@
+import bpy
+
+from ..classes.levelData import LDMeshEntry, LDUnknEntry10, LDUnknEntry18, LevelData
+
+
+def importLevelData(levelDataList: list[LevelData]):
+    if len(levelDataList) > 0:
+        print("Importing LevelData...")
+    else:
+        return
+    
+    rootCollectionName = "LevelData"
+    if rootCollectionName not in bpy.data.collections:
+        bpy.data.collections.new(rootCollectionName)
+        bpy.context.scene.collection.children.link(bpy.data.collections[rootCollectionName])
+    rootCollection = bpy.data.collections[rootCollectionName]
+
+    for levelData in levelDataList:
+        for ldEntry in levelData.entries:
+            for ldObject in ldEntry.objects:
+                if ldObject.meshEntry is not None:
+                    importLdMeshEntry(ldObject.meshEntry, rootCollection)
+                elif ldObject.unknEntry10 is not None:
+                    importLdUnknEntry10(ldObject.unknEntry10, rootCollection)
+                elif ldObject.unknEntry18 is not None:
+                    importLdUnknEntry18(ldObject.unknEntry18, rootCollection)
+
+    print("Done importing LevelData!")
+
+def importLdMeshEntry(meshEntry: LDMeshEntry, collection: bpy.types.Collection):
+    makeObj(
+        meshEntry.pos,
+        meshEntry.rot,
+        meshEntry.scale,
+        meshEntry.meshPath.split("/")[-1],
+        collection,
+    )
+
+def importLdUnknEntry10(unknEntry10: LDUnknEntry10, collection: bpy.types.Collection):
+    makeObj(
+        unknEntry10.pos,
+        unknEntry10.rot,
+        unknEntry10.scale,
+        "UnknEntry10",
+        collection,
+    )
+
+def importLdUnknEntry18(unknEntry18: LDUnknEntry18, collection: bpy.types.Collection):
+    makeObj(
+        unknEntry18.pos,
+        unknEntry18.rot,
+        unknEntry18.scale,
+        unknEntry18.unknPath.split("/")[-1],
+        collection,
+    )
+
+def transformCoords(coords: tuple[float, float, float], invertY = -1):
+    return (coords[0], invertY * coords[2], coords[1])
+
+def makeObj(
+    pos: tuple[float, float, float],
+    rot: tuple[float, float, float, float],
+    scale: float,
+    name: str,
+    collection: bpy.types.Collection,
+):
+    obj = bpy.data.objects.new(name, None)
+    obj.location = transformCoords(pos)
+    obj.rotation_euler = transformCoords(rot[:3])
+    obj.scale = (scale, scale, scale)
+    collection.objects.link(obj)
+    return obj

--- a/importers/meshAsset_import.py
+++ b/importers/meshAsset_import.py
@@ -146,7 +146,7 @@ def construct_meshes(pack):
                     continue
                 matFaces = faces[matObjects.indicesStart//3:matObjects.indicesStart//3 + matObjects.indicesCount//3]
                 for matFace in matFaces:
-                    if (bm.verts[matFace[0]] != bm.verts[matFace[1]] != bm.verts[matFace[2]]):
+                    if (bm.verts[matFace[0]] != bm.verts[matFace[1]] and bm.verts[matFace[0]] != bm.verts[matFace[2]] and bm.verts[matFace[1]] != bm.verts[matFace[2]]):
                         face = bm.faces.get([bm.verts[matFace[0]], bm.verts[matFace[1]], bm.verts[matFace[2]]]).material_index = matObjects.materialIndex
 
             bpy.ops.object.mode_set(mode='OBJECT')

--- a/pack_import.py
+++ b/pack_import.py
@@ -22,7 +22,7 @@ def main(packFilePath, do_extract_textures, do_construct_materials, batch_size, 
         meshPack = Pack(packFile)
     print("\nConstructing Blender Objects...")
     construct_meshes(meshPack)
-    importLevelData(meshPack.levelData)
+    importLevelData(meshPack.levelData, addon_name)
 
     # Import materials + textures
     failedTexturesAssets = []

--- a/pack_import.py
+++ b/pack_import.py
@@ -1,4 +1,6 @@
 import bpy, os
+
+from .importers.levelData_import import importLevelData
 from .classes.pack import *
 from .importers.meshAsset_import import construct_meshes
 from .importers.materialAssets_import import construct_materials, extract_textures
@@ -15,12 +17,12 @@ def main(packFilePath, do_extract_textures, do_construct_materials, batch_size, 
     pack_directory = os.path.dirname(os.path.abspath(packFilePath))
 
     # meshPack
-    packFile = open(packFilePath, "rb")
     print("Parsing Mesh PACK file...", packFilePath)
-    meshPack = Pack(packFile)
+    with open(packFilePath, "rb") as packFile:
+        meshPack = Pack(packFile)
     print("\nConstructing Blender Objects...")
     construct_meshes(meshPack)
-    packFile.close()
+    importLevelData(meshPack.levelData)
 
     # Import materials + textures
     failedTexturesAssets = []
@@ -47,9 +49,8 @@ def main(packFilePath, do_extract_textures, do_construct_materials, batch_size, 
             if (materialPackFullPath not in imported_materialPacks):
                 imported_materialPacks.append(materialPackFullPath)
                 print("Parsing Material PACK file...", path.path)
-                packFile = open(materialPackFullPath, "rb")
-                materialPacks.append(Pack(packFile))
-                packFile.close()
+                with open(materialPackFullPath, "rb") as packFile:
+                    materialPacks.append(Pack(packFile))
 
         #texturePacks
         texturePacks = []
@@ -71,9 +72,8 @@ def main(packFilePath, do_extract_textures, do_construct_materials, batch_size, 
                 if (texturePackFullPath not in imported_texturePacks):
                     imported_texturePacks.append(texturePackFullPath)
                     print("Parsing Texture PACK file...", path.path)
-                    packFile = open(texturePackFullPath, "rb")
-                    texturePacks.append(Pack(packFile))
-                    packFile.close()
+                    with open(texturePackFullPath, "rb") as packFile:
+                        texturePacks.append(Pack(packFile))
 
         if do_extract_textures:
             failedTexturesAssets = extract_textures(pack_directory, texturePacks, noesis_path, batch_size)

--- a/util.py
+++ b/util.py
@@ -22,7 +22,7 @@ def to_ushort(bs):
 	return struct.unpack("<H", bs)[0]
 
 def to_string(bs, encoding = 'utf8'):
-	return bs.split(b'\x00')[0].decode(encoding)
+	return bs.split(b'\x00')[0].decode(encoding, 'replace')
 
 def alignRelative(openFile, relativeStart, alignment):
 	alignOffset = (((openFile.tell() - relativeStart) // alignment) + 1) * alignment
@@ -36,6 +36,21 @@ def uint32_to_bytes(var):
 
 def int32_to_bytes(var):
 	return var.to_bytes(4, byteorder='little', signed=True)
+
+def readFloatX3(f) -> tuple[float, float, float]:
+	return struct.unpack("<fff", f.read(12))
+
+def readFloatX4(f) -> tuple[float, float, float, float]:
+	return struct.unpack("<ffff", f.read(16))
+
+def readString(f) -> str:
+	byteStr = b""
+	while True:
+		byte = f.read(1)
+		if byte == b'\x00':
+			break
+		byteStr += byte
+	return byteStr.decode("utf-8", "replace")
 
 class XonSurfaceDXGIFormat(Enum):
 	UNKNOWN = 0


### PR DESCRIPTION
Changes:
- added LevelData import
  - Useful for importing maps
  - `Import > NieR Replicant Mesh Pack(s)` can import both, meshes and LevelData
  - A separate assets library can be specified in the addon settings
  - Without it only empty placeholders will be imported
- Added import all meshes in folder (recursively) option
- Fixed an (seemingly) infinite loop when importing unsupported pack files (in tpGxAssetHeader.py)